### PR TITLE
Rm no focus test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,7 @@
 # review when someone opens a pull request.
 # see https://help.github.com/articles/about-codeowners/ for more details
 
-* @ThibodeauJF @pochretien @MichelML @sroy3 @GermainBergeron @rousselm4 @gdostie @vseguin
+* @pochretien @MichelML @sroy3 @GermainBergeron @rousselm4 @gdostie
+
+# Prevent PRs that only modify package.json from notifying everyone
+package.json @ghost

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "shelljs": "0.8.1",
-    "tslint": "5.9.1",
+    "tslint": "5.11.0",
     "typescript": "2.6.2",
     "yargs": "10.1.1",
     "typescript-formatter": "7.1.0"

--- a/tslint.json
+++ b/tslint.json
@@ -232,7 +232,6 @@
     "no-inferrable-types": false,
     "no-empty": true,
     "no-eval": true,
-    "no-focused-test": true,
     "no-parameter-properties": false,
     "no-reference": true,
     "no-shadowed-variable": true,


### PR DESCRIPTION
Tried with and without plugin without success, not sure it is really mandatory for our standards so just removed it. If we want this we could try to enforce it outside our code standards. 