### PR TITLE
flexible ignore pattern for unused imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
   },
   "license": "MIT",
   "dependencies": {
+    "lodash": "4.17.10",
     "tslint": "5.11.0",
     "typescript": "2.6.2",
-    "yargs": "10.1.1",
-    "typescript-formatter": "7.1.0"
+    "typescript-formatter": "7.1.0",
+    "yargs": "10.1.1"
   }
 }

--- a/tsjs.js
+++ b/tsjs.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const fs = require('fs');
 const yargs = require('yargs');
+const {flow, update} = require('lodash/fp');
 const {Linter, Configuration} = require('tslint');
 const tsfmt = require('typescript-formatter');
 
@@ -26,19 +27,13 @@ process.on('exit', () => {
 
 try {
     fs.writeFileSync(tempTsfmtFile, JSON.stringify(require(tsfmtPath)));
-
-    let tslintJSON = require(tslintPath);
-    const defaultIgnorePattern = tslintJSON['no-unused-variable'][1]['ignore-pattern'];
-    tslintJSON = {
-        ...tslintJSON,
-        'no-unused-variable': [
-            true,
-            {
-                'ignore-pattern': argv.ignorepattern || defaultIgnorePattern,
-            },
-        ],
-    };
-    fs.writeFileSync(tempTsLintFile, JSON.stringify(require(tslintPath)));
+    fs.writeFileSync(
+        tempTsLintFile,
+        flow(
+            update('no-unused-variable[1].ignore-pattern', (val) => argv.ignorepattern || val),
+            JSON.stringify,
+        )(require(tslintPath)),
+    );
 
     if (argv.all) {
         tsConfigLint = require(tsconfigPath);

--- a/tsjs.js
+++ b/tsjs.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const fs = require('fs');
 const yargs = require('yargs');
-const {Linter, Configuration} = require('tslint');
+const { Linter, Configuration } = require('tslint');
 const tsfmt = require('typescript-formatter');
 
 yargs.array('exclude');
@@ -15,7 +15,7 @@ const tempTsLintFile = '.tslint.temp.json';
 const tempTsfmtFile = '.tsfmt.temp.json';
 const tempTsConfigFile = '.tsconfig.lint.temp.json';
 let tsConfigFile = argv.tsconfig || 'tsconfig.json';
-let tsConfigLint = {exclude: []};
+let tsConfigLint = { exclude: [] };
 const tsLintExcludeOptionArray = argv.exclude || [];
 
 process.on('exit', () => {
@@ -26,7 +26,20 @@ process.on('exit', () => {
 
 try {
     fs.writeFileSync(tempTsfmtFile, JSON.stringify(require(tsfmtPath)));
+
+    let tslintJSON = require(tslintPath);
+    const defaultIgnorePattern = tslintJSON['no-unused-variable'][1]['ignore-pattern'];
+    tslintJSON = {
+        ...tslintJSON,
+        'no-unused-variable': [
+            true,
+            {
+                'ignore-pattern': argv.ignorepattern || defaultIgnorePattern,
+            },
+        ],
+    };
     fs.writeFileSync(tempTsLintFile, JSON.stringify(require(tslintPath)));
+
     if (argv.all) {
         tsConfigLint = require(tsconfigPath);
         tsConfigLint.exclude = [...tsConfigLint.exclude, ...tsLintExcludeOptionArray];
@@ -45,7 +58,7 @@ try {
 
     console.log('\nRunning tslint...\n');
     const program = Linter.createProgram(tsConfigFile, '.');
-    const linter = new Linter({fix: true}, program);
+    const linter = new Linter({ fix: true }, program);
 
     const files = Linter.getFileNames(program);
     files.forEach((file) => {

--- a/tsjs.js
+++ b/tsjs.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const fs = require('fs');
 const yargs = require('yargs');
-const { Linter, Configuration } = require('tslint');
+const {Linter, Configuration} = require('tslint');
 const tsfmt = require('typescript-formatter');
 
 yargs.array('exclude');
@@ -15,7 +15,7 @@ const tempTsLintFile = '.tslint.temp.json';
 const tempTsfmtFile = '.tsfmt.temp.json';
 const tempTsConfigFile = '.tsconfig.lint.temp.json';
 let tsConfigFile = argv.tsconfig || 'tsconfig.json';
-let tsConfigLint = { exclude: [] };
+let tsConfigLint = {exclude: []};
 const tsLintExcludeOptionArray = argv.exclude || [];
 
 process.on('exit', () => {
@@ -58,7 +58,7 @@ try {
 
     console.log('\nRunning tslint...\n');
     const program = Linter.createProgram(tsConfigFile, '.');
-    const linter = new Linter({ fix: true }, program);
+    const linter = new Linter({fix: true}, program);
 
     const files = Linter.getFileNames(program);
     files.forEach((file) => {


### PR DESCRIPTION
following the addition of the `obsolete imports removal` feature, this PR adds the option of providing your own ignore-pattern to keep unused imports that may be relevant in your project but not elsewhere.