### PR TITLE
set tslint no-unused-var rule to undefined in initial tslint.json for webpack linter not to use this rule

### DIFF
--- a/tsjs.js
+++ b/tsjs.js
@@ -54,13 +54,22 @@ process.on('exit', () => {
     fs.unlinkSync(tempTsLintFile);
 });
 
+const setNoUnusedVar = update(
+    'no-unused-variable',
+    () => tsjs.nounusedvar ? [true, {'ignore-pattern': '([Rr]eact|Store)'}] : undefined
+);
+
+const setNoUnusedVarIgnorePattern = (tslintConfig) => tslintConfig['no-unused-variable']
+    ? update('no-unused-variable[1].ignore-pattern', (val) => tsjs.ignorepattern || val)(tslintConfig)
+    : tslintConfig;
+
 try {
     fs.writeFileSync(tempTsfmtFile, JSON.stringify(require(tsfmtPath)));
     fs.writeFileSync(
         tempTsLintFile,
         flow(
-            update('no-unused-variable[1].ignore-pattern', (val) => tsjs.ignorepattern || val),
-            update('no-unused-variable', (val) => (tsjs.nounusedvar && val) || undefined),
+            setNoUnusedVar,
+            setNoUnusedVarIgnorePattern,
             JSON.stringify
         )(require(tslintPath))
     );

--- a/tslint.json
+++ b/tslint.json
@@ -96,10 +96,6 @@
     "no-unnecessary-initializer": true,
     "no-unsafe-finally": true,
     "no-unused-expression": false,
-    "no-unused-variable": [
-      true,
-      {"ignore-pattern": "([Rr]eact|Store)"}
-    ],
     "no-var-keyword": true,
     "no-var-requires": true,
     "one-line": [


### PR DESCRIPTION
the previous logic of the nounusedvar flag was only working with tsjs cli 