### PR TITLE
Add the rules of react hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "lodash": "4.17.10",
     "tslint": "5.11.0",
+    "tslint-react-hooks": "1.1.0",
     "typescript": "2.6.2",
     "typescript-formatter": "7.1.0",
     "yargs": "10.1.1"

--- a/react_redux/README.md
+++ b/react_redux/README.md
@@ -23,6 +23,7 @@ Other Standards
   1. [Ordering](#ordering)
   1. [`isMounted`](#ismounted)
   1. [Redux](#redux)
+  1. [Hooks](#hooks)
 
 ## Basic Rules
 
@@ -525,6 +526,10 @@ Other Standards
   - The file name for your actions should be the name of the component + the suffix `Actions`.
 
   - The file name for your reducers should be the name of the component + the suffix `Reducers`.
+
+## Hooks
+
+Follow the [rules of hooks](https://reactjs.org/docs/hooks-rules.html) as defined by react maintainers.
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    "tslint-react-hooks"
+  ],
   "rules": {
     "align": [
       true,
@@ -129,6 +132,7 @@
       "avoid-escape"
     ],
     "radix": true,
+    "react-hooks-nesting": "error",
     "semicolon": [
       true,
       "always"
@@ -183,7 +187,10 @@
       "check-type",
       "check-typecast"
     ],
-    "linebreak-style": [true, "CRLF"]
+    "linebreak-style": [
+      true,
+      "CRLF"
+    ]
   },
   "jsRules": {
     "align": [
@@ -318,6 +325,9 @@
       "check-type",
       "check-typecast"
     ],
-    "linebreak-style": [true, "CRLF"]
+    "linebreak-style": [
+      true,
+      "CRLF"
+    ]
   }
 }


### PR DESCRIPTION
The new React hooks feature requires a new set of rules (https://reactjs.org/docs/hooks-rules.html). The react team created an eslint plugin for it and it has been ported to tslint (https://www.npmjs.com/package/tslint-react-hooks). Made the necessary ajustments so that our linter enforces those new rules.