### PR TITLE
feat(prettier)!: use default EoL (`lf`)

### DIFF
--- a/prettier-config.js
+++ b/prettier-config.js
@@ -3,5 +3,4 @@ module.exports = {
     tabWidth: 4,
     singleQuote: true,
     bracketSpacing: false,
-    endOfLine: 'auto',
 };


### PR DESCRIPTION
This allows Windows user to commit consistent.
The changes was made in prettier 2, and is explained in length [here](https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-endofline-to-lf-7435httpsgithubcomprettierprettierpull7435-by-kachkaevhttpsgithubcomkachkaev)

BREAKING CHANGE: All `CRLF` will be either flagged up, or transformed into `LF` by prettier depending if prettier is run with `--check` or `--write`