### PR TITLE
fix no-shadow false positive

### DIFF
--- a/eslint-config.js
+++ b/eslint-config.js
@@ -161,12 +161,8 @@ module.exports = {
         'no-multiple-empty-lines': 'off',
         'no-new-wrappers': 'error',
         'no-redeclare': 'error',
-        'no-shadow': [
-            'error',
-            {
-                hoist: 'all',
-            },
-        ],
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': ['error'],
         'no-trailing-spaces': 'off',
         'no-undef-init': 'error',
         'no-underscore-dangle': 'error',


### PR DESCRIPTION
This should fix false positives of type `'Foo' is already declared in the upper scope on line 1 column`. See https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-shadow.md#how-to-use